### PR TITLE
Ensure that we enforce a permanent display when HDMI "disconnects"

### DIFF
--- a/raspberrypi
+++ b/raspberrypi
@@ -199,6 +199,36 @@ disable_underscan() {
   sudo sed -i 's/#disable_overscan=1/disable_overscan=1/' /boot/config.txt
 }
 
+# Ensure for bookworm that when turning off the connected display instead of it
+# disconnecting and causing Chrome to come out of fullscreen due to re-assessing
+# the display, we now we enforce a permanent display when HDMI is "disconnected"
+# We need to check which HDMI port is connected and inject to the boot cmdlines
+#   1) Is HDMI port nearest to power
+#   2) next one
+#   3) we don't use here, but means both are connected
+# This means that if we setup on 1 and connect to port 2 we will get a seperate
+# display instead of the "main" one. Re-running this script will always update.
+force_hdmi_display() {
+  ACTIVE_HDMI_PORT=`wlr-randr | grep HDMI | grep -v null`
+  BOOT_CMD_FILE=/boot/firmware/cmdline.txt
+  sudo cp "$BOOT_CMD_FILE" "$BOOT_CMD_FILE".bkp
+
+  HDMI_PORT=1
+  HOTPLUG_CMD=vc4.force_hotplug
+
+  if [[ "$ACTIVE_HDMI_PORT" =~ "HDMI-A-2" ]]; then
+    HDMI_PORT=2
+  fi
+
+  if grep -q "$HOTPLUG_CMD" $BOOT_CMD_FILE; then
+    echo "Amending existing HDMI hot plug setting"
+    sed "s/$HOTPLUG_CMD=[1-3]/$HOTPLUG_CMD=$HDMI_PORT/" $BOOT_CMD_FILE | xargs echo -n | sudo tee $BOOT_CMD_FILE
+  else
+    echo "Setting up HDMI hotplug"
+    echo -n " $HOTPLUG_CMD=$HDMI_PORT" | sudo tee -a $BOOT_CMD_FILE
+  fi
+}
+
 
 # Display logo and intro to user
 # ASCII display generated at https://www.ascii-art-generator.org/
@@ -270,7 +300,14 @@ log "setting up Geckoboard kiosk mode"
 # Wayfire compositor handles autostart so check the session
 # and use the wayland installation as we can't support any X11 stuff
 if [[ $DESKTOP_SESSION = $WAYFIRE_SESSION_NAME ]]; then
+  force_hdmi_display
   install_kiosk_script_for_wayland
+
+  # The wayfire service monitors config changes which causes
+  # the user to be logged out so they don't see the setup complete message
+  # So lets just trigger a reboot immediately otherwise the force hdmi will
+  # not have applied
+  reboot
 else
   install_kiosk_script
 fi


### PR DESCRIPTION
A customer reported that daily their Chrome instance was no longer fullscreen, after testing it wasn't possible replicate with the screen continously being left on - after trying turning off the screen as something some people would do overnight this immediately caused Chrome to no longer be fullscreen.

Journalctl showed the following events occuring when turning an attached screen off and then back on

```
Sep 10 14:37:17 pi rpi-connect-wayvnc[1372]: Warning: ../src/main.c: 322: Selected output HDMI-A-1 went away
Sep 10 14:37:17 pi rpi-connect-wayvnc[1372]: ERROR: ../src/main.c: 338: No fallback outputs left. Exiting...
Sep 10 14:37:17 pi systemd[973]: Starting rpi-connect-wayvnc-watcher.service - Reload rpi-connect when rpi-connect-wayvnc changes...
Sep 10 14:37:17 pi systemd[973]: Reloading rpi-connect.service - Raspberry Pi Connect...
Sep 10 14:37:17 pi rpi-connect[2162]: ✓ Reloaded
Sep 10 14:37:17 pi rpi-connect-wayvnc[2167]: ERROR: ../src/ctl-client.c: 115: Failed to find socket path "/run/user/1000/rpi-connect-wayvnc-ctl.sock": No such file or directory
Sep 10 14:37:17 pi systemd[973]: rpi-connect-wayvnc.service: Control process exited, code=exited, status=1/FAILURE
Sep 10 14:37:17 pi systemd[973]: Reloaded rpi-connect.service - Raspberry Pi Connect.
Sep 10 14:37:17 pi systemd[973]: rpi-connect-wayvnc.service: Failed with result 'exit-code'.
Sep 10 14:37:17 pi systemd[973]: Finished rpi-connect-wayvnc-watcher.service - Reload rpi-connect when rpi-connect-wayvnc changes.
Sep 10 14:37:20 pi NetworkManager[824]: <info>  [1725989840.6104] agent-manager: agent[9b5aa7f9957efc21,:1.45/org.freedesktop.nm-applet/1000]: agent registered
Sep 10 14:37:20 pi PackageKit[1665]: uid 1000 is trying to obtain org.freedesktop.packagekit.system-sources-refresh auth (only_trusted:0)
Sep 10 14:37:20 pi PackageKit[1665]: uid 1000 obtained auth for org.freedesktop.packagekit.system-sources-refresh
Sep 10 14:37:22 pi systemd[973]: rpi-connect-wayvnc.service: Scheduled restart job, restart counter is at 2.
Sep 10 14:37:22 pi systemd[973]: Stopped rpi-connect-wayvnc.service - WayVNC process used by Raspberry Pi Connect.
Sep 10 14:37:22 pi systemd[973]: Starting rpi-connect-wayvnc.service - WayVNC process used by Raspberry Pi Connect...
Sep 10 14:37:22 pi systemd[973]: Started rpi-connect-wayvnc.service - WayVNC process used by Raspberry Pi Connect.
Sep 10 14:37:22 pi PackageKit[1665]: refresh-cache transaction /42_adcabccd from uid 1000 finished with success after 1580ms
Sep 10 14:37:22 pi systemd[973]: Starting rpi-connect-wayvnc-watcher.service - Reload rpi-connect when rpi-connect-wayvnc changes...
Sep 10 14:37:22 pi systemd[973]: Reloading rpi-connect.service - Raspberry Pi Connect...
Sep 10 14:37:22 pi rpi-connect[2707]: ✓ Reloaded
Sep 10 14:37:22 pi systemd[973]: Reloaded rpi-connect.service - Raspberry Pi Connect.
Sep 10 14:37:22 pi systemd[973]: Finished rpi-connect-wayvnc-watcher.service - Reload rpi-connect when rpi-connect-wayvnc changes.
Sep 10 14:37:26 pi PackageKit[1665]: get-updates transaction /43_cceaabaa from uid 1000 finished with success after 3733ms
```

Turns out after some research that this is likely some Chrome specific bug https://github.com/raspberrypi/bookworm-feedback/issues/215 as this apparently doesn't occur with Firefox, however there is some fix to prevent it from happening, we can enforce some vc4.force_hotplug - which always maintains the display permanently - meaning that when the HDMI is disconnected the above HDMI-A-* went away no longer occurs causing Chrome to never come out of fullscreen.

Hopefully once this is fixed in Chrome we can remove this boot cmdline change.

Also it was observed that the wayfire service logs out the user when changing the config meaning that they don't see the setup complete - instead of trying to workaround it lets just restart immediately after completion so that boot config is applied and they are booted into the kiosk mode immediately.