### PR TITLE
Support using basic password store in Chrome startup kiosk script

### DIFF
--- a/raspberrypi
+++ b/raspberrypi
@@ -54,6 +54,8 @@ check_raspberrypi() {
   fi
 }
 
+CHROME_PWDSTORE_SWITCH=""
+
 install_kiosk_script() {
   GECKOBOARD_KIOSK_FILE=$HOME/.local/geckoboard_kiosk_mode
   LABWC_CONFIG_PATH=$HOME/.config/labwc
@@ -69,12 +71,10 @@ sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' $HOME/.config/chromium/
 sed -i 's/"exit_type":"Crashed"/"exit_type":"Normal"/' $HOME/.config/chromium/Default/Preferences
 
 # Disable any installed extentions and the default browser check and error dialogs
-# We need to add the switch start-maximized otherwise on wayland it will 
-# start as a pixel size and not displayed using start-maximized fixes that
 chromium \
+$CHROME_PWDSTORE_SWITCH \
+--kiosk \
 --disable-extensions \
---start-maximized \
---start-fullscreen \
 --no-default-browser-check \
 https://app.geckoboard.com/tv
 
@@ -143,6 +143,20 @@ log "installing color emoji support"
 install_color_emoji > /dev/null
 
 log "setting up Geckoboard kiosk mode"
+
+printf "\nTo prevent default keyring requesting password input when opening Chrome\n"
+printf "We're going to instruct Chrome to store passwords unencrypted in its own store\n"
+printf "This would be the same as setting no password in your keyring\n"
+printf "If you intend to store the passwords in Chrome for websites\n"
+printf "It would be highly recommended not to use the unencrypted password store\n\n"
+
+printf "Do you want to use unencrypted password store for Chrome? [y/N]:"
+
+read disableKeyring
+
+if [[ "$disableKeyring" == "y" ]]; then
+  CHROME_PWDSTORE_SWITCH="--password-store=basic"
+fi
 
 install_kiosk_script
 


### PR DESCRIPTION
This adds support to disable the keyring access and for Chrome to use its internal basic store.

In any normal setup - we would never want to disable using the encrypted keyring store - however for kiosk setups they are inheritly unsecure by nature - with the device auto logging in, and requring no human interaction when rebooted.

Even if we introduced a setup that would auto unlock the keyring on login - as the login will be automatic with no human interaction - this setup would be no-more secure than to just storing the passwords unencrypted.

So as the latest Chrome build now requests setting up a default keyring password when opening - which most setups will not care about - because they are not storing any username/passwords - we can offer to use the unencrypted keyring store.

So in the rare case that someones setup with this is actually behind a manual login after each boot and requires logging into another service that requires storing the username/password, we can allow them not to use the unencrypted keyring store.

So this script is updated which now;
- Prompts if you want to use unencrypted keyring store
- Saying yes passes a new password-store=basic in the kiosk script to chrome
- Saying no doesn't pass the switch and will use the default keyring

Also since setting up a device from scratch I noticed that start-fullscreen/maximized was giving some unexpected behavour in fullscreen mode - so from testing we can actually go back to the `--kiosk` switch which used to be case with X11 setups - but when wayland was introduced it didn't work - but thats now since changed, so we can go back to kiosk mode.

https://peter.sh/experiments/chromium-command-line-switches/#password-store